### PR TITLE
Upgrade to bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,23 @@ repository = "https://github.com/Selene-Amanita/bevy_basic_portals"
 authors = ["Selene Amanita"]
 
 [dependencies]
-bevy_app = "0.12"
-bevy_asset = "0.12"
-bevy_core_pipeline = "0.12"
-bevy_ecs = "0.12"
-bevy_hierarchy = "0.12"
-bevy_math = "0.12"
-bevy_pbr = "0.12"
-bevy_reflect = "0.12" # Could potentially be under a feature?
-bevy_render = "0.12"
-bevy_transform = "0.12"
-bevy_window = "0.12"
+bevy_app = "0.13"
+bevy_asset = "0.13"
+bevy_core_pipeline = "0.13"
+bevy_ecs = "0.13"
+bevy_hierarchy = "0.13"
+bevy_math = "0.13"
+bevy_pbr = "0.13"
+bevy_reflect = "0.13" # Could potentially be under a feature?
+bevy_render = "0.13"
+bevy_transform = "0.13"
+bevy_window = "0.13"
 tracing = { version = "0.1", default-features = false, features = ["std"] } # From bevy_utils
 # All of the above can be replaced by:
-# bevy = { version = "0.12", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", ] }
+# bevy = { version = "0.13", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", ] }
 
 [dev-dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fn setup(
         ..default()
     });
 
-    let portal_mesh = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(10., 10.))));
+    let portal_mesh = meshes.add(Rectangle::new(10., 10.));
     commands.spawn(CreatePortalBundle {
         mesh: portal_mesh,
         // This component will be deleted and things that are needed to create the portal will be created
@@ -55,7 +55,7 @@ fn setup(
         ..default()
     });
 
-    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere{radius: 2., ..default()}));
+    let sphere_mesh = meshes.add(Sphere::new(2.).mesh().uv(32, 18));
     commands.spawn(PbrBundle {
         mesh: sphere_mesh,
         transform: Transform::from_xyz(20.,0.,-5.),

--- a/assets/portal.wgsl
+++ b/assets/portal.wgsl
@@ -2,9 +2,9 @@
 #import bevy_pbr::mesh_bindings
 #import bevy_pbr::forward_io::VertexOutput
 
-@group(1) @binding(0)
+@group(2) @binding(0)
 var texture: texture_2d<f32>;
-@group(1) @binding(1)
+@group(2) @binding(1)
 var texture_sampler: sampler;
 
 @fragment

--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -23,7 +23,7 @@ fn setup(
         ..default()
     });
 
-    let portal_mesh = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(10., 10.))));
+    let portal_mesh = meshes.add(Mesh::from(Rectangle::new(10., 10.)));
     commands.spawn(CreatePortalBundle {
         mesh: portal_mesh,
         // This component will be deleted and things that are needed to create the portal will be created
@@ -42,7 +42,7 @@ fn setup(
         ..default()
     });
 
-    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere{radius: 2., ..default()}));
+    let sphere_mesh = meshes.add(Mesh::from(Sphere::new(2.).mesh().uv(32, 18)));
     commands.spawn(PbrBundle {
         mesh: sphere_mesh,
         transform: Transform::from_xyz(20.,0.,-5.),

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -50,7 +50,7 @@ fn setup(
     // Lights
     commands.insert_resource(AmbientLight {
         color: Color::WHITE,
-        brightness: 80.,
+        brightness: 10.,
     });
 
     commands.insert_resource(ClearColor(Color::rgb(0., 0., 0.)));

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -66,7 +66,7 @@ fn setup(
     let spawn_portal_dir = Vec3::Z;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(1);
-    let shape = meshes.add(shape::Cube::new(5.).into());
+    let shape = meshes.add(shape::Cube::new(5.));
     let color = Color::YELLOW;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), true);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -76,7 +76,7 @@ fn setup(
     let spawn_portal_dir = -Vec3::Z;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(2);
-    let shape = meshes.add(shape::Box::from_corners(Vec3::new(1.,4.,1.), Vec3::new(-1.,-1.,-2.)).into());
+    let shape = meshes.add(shape::Box::from_corners(Vec3::new(1.,4.,1.), Vec3::new(-1.,-1.,-2.)));
     let color = Color::BLUE;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), true);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -86,7 +86,7 @@ fn setup(
     let spawn_portal_dir = Vec3::X;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(3);
-    let shape = meshes.add(shape::Capsule {radius: 3., depth: 3., ..default()}.into());
+    let shape = meshes.add(shape::Capsule {radius: 3., depth: 3., ..default()});
     let color = Color::GREEN;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), true);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -96,7 +96,7 @@ fn setup(
     let spawn_portal_dir = -Vec3::X;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(4);
-    let shape = meshes.add(shape::Capsule {radius: 3., depth: 3., ..default()}.into());
+    let shape = meshes.add(shape::Capsule {radius: 3., depth: 3., ..default()});
     let color = Color::FUCHSIA;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), false);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -106,7 +106,7 @@ fn setup(
     let spawn_portal_dir = Vec3::Y;
     let spawn_portal_up = -Vec3::Z;
     let render_layer = RenderLayers::layer(5);
-    let shape = meshes.add(shape::Cube::new(5.).into());
+    let shape = meshes.add(shape::Cube::new(5.));
     let color = Color::RED;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), false);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -116,7 +116,7 @@ fn setup(
     let spawn_portal_dir = -Vec3::Y;
     let spawn_portal_up = -Vec3::Z;
     let render_layer = RenderLayers::layer(6);
-    let shape = meshes.add(shape::Torus {radius: 3., ring_radius: 1., ..default()}.into());
+    let shape = meshes.add(shape::Torus {radius: 3., ring_radius: 1., ..default()});
     let color = Color::CYAN;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), false);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -56,7 +56,7 @@ fn setup(
     commands.insert_resource(ClearColor(Color::rgb(0., 0., 0.)));
 
     // Scenes
-    let portal_mesh = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(scenes::PORTAL_SIZE, scenes::PORTAL_SIZE))));
+    let portal_mesh = meshes.add(Mesh::from(Rectangle::new(scenes::PORTAL_SIZE, scenes::PORTAL_SIZE)));
 
     let debug_material = materials.add(textures::debug_material(&mut images, 1, Some(Face::Back)));
 
@@ -66,7 +66,7 @@ fn setup(
     let spawn_portal_dir = Vec3::Z;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(1);
-    let shape = meshes.add(shape::Cube::new(5.));
+    let shape = meshes.add(Cuboid::new(5., 5., 5.));
     let color = Color::YELLOW;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), true);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -76,7 +76,7 @@ fn setup(
     let spawn_portal_dir = -Vec3::Z;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(2);
-    let shape = meshes.add(shape::Box::from_corners(Vec3::new(1.,4.,1.), Vec3::new(-1.,-1.,-2.)));
+    let shape = meshes.add(Cuboid::from_corners(Vec3::new(1.,4.,1.), Vec3::new(-1.,-1.,-2.)));
     let color = Color::BLUE;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), true);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -86,7 +86,7 @@ fn setup(
     let spawn_portal_dir = Vec3::X;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(3);
-    let shape = meshes.add(shape::Capsule {radius: 3., depth: 3., ..default()});
+    let shape = meshes.add(Capsule3d::new(3., 3.));
     let color = Color::GREEN;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), true);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -96,7 +96,7 @@ fn setup(
     let spawn_portal_dir = -Vec3::X;
     let spawn_portal_up = Vec3::Y;
     let render_layer = RenderLayers::layer(4);
-    let shape = meshes.add(shape::Capsule {radius: 3., depth: 3., ..default()});
+    let shape = meshes.add(Capsule3d::new(3., 3.));
     let color = Color::FUCHSIA;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), false);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -106,7 +106,7 @@ fn setup(
     let spawn_portal_dir = Vec3::Y;
     let spawn_portal_up = -Vec3::Z;
     let render_layer = RenderLayers::layer(5);
-    let shape = meshes.add(shape::Cube::new(5.));
+    let shape = meshes.add(Cuboid::new(5., 5., 5.));
     let color = Color::RED;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), false);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),
@@ -116,7 +116,7 @@ fn setup(
     let spawn_portal_dir = -Vec3::Y;
     let spawn_portal_up = -Vec3::Z;
     let render_layer = RenderLayers::layer(6);
-    let shape = meshes.add(shape::Torus {radius: 3., ring_radius: 1., ..default()});
+    let shape = meshes.add(Torus::new(2.5, 3.5));
     let color = Color::CYAN;
     scenes::setup_portal_cube_face(&mut commands, spawn_portal_dir, spawn_portal_up, main_camera, render_layer, portal_mesh.clone(), false);
     scenes::setup_scene_test(&mut commands, spawn_portal_dir, spawn_portal_up, render_layer, portal_mesh.clone(),

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -50,7 +50,7 @@ fn setup(
     // Lights
     commands.insert_resource(AmbientLight {
         color: Color::WHITE,
-        brightness: 0.01,
+        brightness: 80.,
     });
 
     commands.insert_resource(ClearColor(Color::rgb(0., 0., 0.)));

--- a/examples/cube/scenes.rs
+++ b/examples/cube/scenes.rs
@@ -93,7 +93,7 @@ pub fn setup_scene_test (
             PointLightBundle {
                 point_light: PointLight {
                     color,
-                    intensity: 9000.0,
+                    intensity: 1_000_000.0,
                     range: DESTINATION_DISTANCE - PORTAL_SIZE,
                     shadows_enabled: true,
                     ..default()

--- a/examples/mirror/main.rs
+++ b/examples/mirror/main.rs
@@ -59,7 +59,7 @@ fn setup(
     let torus_mesh = meshes.add(Mesh::from(shape::Torus{radius:2.5, ring_radius:0.5, ..default()}));
     let torus = commands.spawn(PbrBundle {
         mesh: torus_mesh,
-        material: materials.add(Color::WHITE.into()),
+        material: materials.add(Color::WHITE),
         transform: Transform::from_xyz(0., 0., -5.),
         ..default()
     }).id();

--- a/examples/mirror/main.rs
+++ b/examples/mirror/main.rs
@@ -48,7 +48,7 @@ fn setup(
 
     // Cube
     let debug_material = materials.add(textures::debug_material(&mut images, 1, None));
-    let cube_mesh = meshes.add(Mesh::from(shape::Cube{size:5.}));
+    let cube_mesh = meshes.add(Cuboid::new(5., 5., 5.));
     commands.spawn(PbrBundle {
         mesh: cube_mesh,
         material: debug_material,
@@ -56,7 +56,7 @@ fn setup(
     });
     
     // Torus
-    let torus_mesh = meshes.add(Mesh::from(shape::Torus{radius:2.5, ring_radius:0.5, ..default()}));
+    let torus_mesh = meshes.add(Torus::new(2.25, 2.75));
     let torus = commands.spawn(PbrBundle {
         mesh: torus_mesh,
         material: materials.add(Color::WHITE),
@@ -65,7 +65,7 @@ fn setup(
     }).id();
 
     // Mirror
-    let portal_mesh = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(10., 10.))));
+    let portal_mesh = meshes.add(Rectangle::new(10., 10.));
     let portal_transform = Transform::from_xyz(0., 0., -10.);
     let mut mirror = commands.spawn(CreatePortalBundle {
         mesh: portal_mesh,

--- a/examples/mirror/main.rs
+++ b/examples/mirror/main.rs
@@ -28,7 +28,7 @@ fn setup(
     // Light
     commands.insert_resource(AmbientLight {
         color: Color::WHITE,
-        brightness: 0.4,
+        brightness: 80.,
     });
     commands.insert_resource(ClearColor(Color::rgb(0.1, 0.1, 0.2)));
 

--- a/examples/moving/main.rs
+++ b/examples/moving/main.rs
@@ -56,7 +56,7 @@ fn setup(
         MainCamera
     )).id();
 
-    let portal_mesh = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(10., 10.))));
+    let portal_mesh = meshes.add(Rectangle::new(10., 10.));
     commands.spawn(CreatePortalBundle {
         mesh: portal_mesh,
         create_portal: CreatePortal {
@@ -70,7 +70,7 @@ fn setup(
         ..default()
     });
 
-    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere{radius: 2., ..default()}));
+    let sphere_mesh = meshes.add(Sphere::new(2.).mesh().uv(32, 18));
     commands.spawn(PbrBundle {
         mesh: sphere_mesh,
         transform: SPHERE_TRANSFORM,

--- a/examples/shapes/main.rs
+++ b/examples/shapes/main.rs
@@ -45,7 +45,7 @@ fn setup(
     // Lights
     commands.insert_resource(AmbientLight {
         color: Color::WHITE,
-        brightness: 0.3,
+        brightness: 80.,
     });
 
     commands.insert_resource(ClearColor(Color::rgb(0., 0., 0.)));

--- a/examples/shapes/main.rs
+++ b/examples/shapes/main.rs
@@ -52,17 +52,17 @@ fn setup(
 
     // Sphere
     let debug_material = materials.add(textures::debug_material(&mut images, 3, Some(Face::Back)));
-    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere{radius: 2.5, ..default()}));
+    let sphere_mesh = meshes.add(Sphere::new(2.5).mesh().uv(32, 18));
     setup_object_and_portal(&mut commands, main_camera, sphere_mesh, debug_material.clone(), Transform::from_xyz(10.,0.,0.), Some(Face::Back));
 
     // Cube
     let debug_material = materials.add(textures::debug_material(&mut images, 2, Some(Face::Back)));
-    let cube_mesh = meshes.add(Mesh::from(shape::Cube::new(5.)));
+    let cube_mesh = meshes.add(Cuboid::new(5., 5., 5.));
     setup_object_and_portal(&mut commands, main_camera, cube_mesh, debug_material.clone(), Transform::from_xyz(-10.,0.,0.), Some(Face::Back));
 
     // double-sided Quad
     let debug_material = materials.add(textures::debug_material(&mut images, 1, None));
-    let quad_mesh = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(5.,5.))));
+    let quad_mesh = meshes.add(Rectangle::new(5., 5.));
     setup_object_and_portal(&mut commands, main_camera, quad_mesh, debug_material.clone(), Transform::from_xyz(0.,0.,-10.), None);
 }
 

--- a/helpers/pivot_cameras.rs
+++ b/helpers/pivot_cameras.rs
@@ -54,12 +54,12 @@ impl Default for PivotCamerasConfig {
             keyboard_zoom_speed: DEFAULT_KEYBOARD_ZOOM_SPEED,
             mouse_speed: DEFAULT_MOUSE_SPEED,
             mouse_zoom_speed: DEFAULT_MOUSE_ZOOM_SPEED,
-            keyboard_left_key: KeyCode::Left,
-            keyboard_right_key: KeyCode::Right,
-            keyboard_up_key: KeyCode::Up,
-            keyboard_down_key: KeyCode::Down,
-            keyboard_forward_key: KeyCode::Z,
-            keyboard_backward_key: KeyCode::A,
+            keyboard_left_key: KeyCode::ArrowLeft,
+            keyboard_right_key: KeyCode::ArrowRight,
+            keyboard_up_key: KeyCode::ArrowUp,
+            keyboard_down_key: KeyCode::ArrowDown,
+            keyboard_forward_key: KeyCode::KeyZ,
+            keyboard_backward_key: KeyCode::KeyA,
         }
     }
 }
@@ -114,8 +114,8 @@ struct Move {
 fn update_pivot_cameras(
     config: Res<PivotCamerasConfig>,
     time: Res<Time>,
-    keyboard_input: Res<Input<KeyCode>>,
-    mouse_input: Res<Input<MouseButton>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mouse_input: Res<ButtonInput<MouseButton>>,
     mut motion_evr: EventReader<MouseMotion>,
     mut scroll_evr: EventReader<MouseWheel>,
     mut pivot_camera_query: Query<(&mut Transform, &PivotCamera)>
@@ -178,7 +178,7 @@ fn update_pivot_cameras(
             // Vertical movement
             // TODO (should maybe restrict to not go above?)
             let local_x = transform.local_x();
-            transform.rotate_around(pivot_camera.pivot, Quat::from_axis_angle(local_x, move_cam.v));
+            transform.rotate_around(pivot_camera.pivot, Quat::from_axis_angle(*local_x, move_cam.v));
     
             // Horizontal movement
             transform.rotate_around(pivot_camera.pivot, Quat::from_axis_angle(Vec3::Y, move_cam.h));

--- a/helpers/textures.rs
+++ b/helpers/textures.rs
@@ -8,6 +8,7 @@ use bevy::{
         Face
     },
 };
+use bevy_render::render_asset::RenderAssetUsages;
 
 /// Creates a colorful test pattern (copied from bevy's 3d_shape example)
 pub fn uv_debug_texture(darkness: u8) -> Image {
@@ -36,6 +37,7 @@ pub fn uv_debug_texture(darkness: u8) -> Image {
         TextureDimension::D2,
         &texture_data,
         TextureFormat::Rgba8UnormSrgb,
+        RenderAssetUsages::default(),
     )
 }
 

--- a/src/portals/api.rs
+++ b/src/portals/api.rs
@@ -1,4 +1,4 @@
-///! Components and structs to create portals without caring about their implementation
+//! Components and structs to create portals without caring about their implementation
 
 use bevy_app::prelude::*;
 use bevy_asset::Handle;

--- a/src/portals/create.rs
+++ b/src/portals/create.rs
@@ -279,7 +279,9 @@ fn create_portal(
             visibility: Visibility::Hidden,
             ..SpatialBundle::default()
         },
-        create_portal.render_layer
+        create_portal.render_layer,
+        camera_bundle.exposure,
+        camera_bundle.main_texture_usages,
     )).id();
 
     // Add portal components

--- a/src/portals/create.rs
+++ b/src/portals/create.rs
@@ -343,8 +343,8 @@ fn create_portal(
             commands.entity(destination_entity).with_children(|parent| {
                 parent.spawn((
                     PbrBundle {
-                        mesh: meshes.add(shape::Icosphere {radius:0.1, ..shape::Icosphere::default()}.try_into().unwrap()),
-                        material: materials.add(debug_color.into()),
+                        mesh: meshes.add(Sphere::new(0.1).mesh().ico(5).unwrap()),
+                        material: materials.add(debug_color),
                         ..PbrBundle::default()
                     },
                     create_portal.render_layer
@@ -377,8 +377,8 @@ fn create_portal(
             commands.entity(portal_camera_entity).with_children(|parent| {
                 parent.spawn((
                     PbrBundle {
-                        mesh: meshes.add(shape::Icosphere {radius:0.1, ..shape::Icosphere::default()}.try_into().unwrap()),
-                        material: materials.add(debug_color.into()),
+                        mesh: meshes.add(Sphere::new(0.1).mesh().ico(5).unwrap()),
+                        material: materials.add(debug_color),
                         visibility: Visibility::Visible,
                         ..PbrBundle::default()
                     },

--- a/src/portals/create.rs
+++ b/src/portals/create.rs
@@ -1,4 +1,4 @@
-///! Components, systems and command for the creation of portals
+//! Components, systems and command for the creation of portals
 
 use bevy_app::prelude::*;
 use bevy_asset::prelude::*;
@@ -393,6 +393,7 @@ fn create_portal(
 
 /// [SystemParam] needed for [create_portals]
 #[derive(SystemParam)]
+#[allow(clippy::type_complexity)]
 pub struct CreatePortalParams<'w, 's> {
     commands: Commands<'w, 's>,
     portal_materials: ResMut<'w, Assets<PortalMaterial>>,

--- a/src/portals/despawn.rs
+++ b/src/portals/despawn.rs
@@ -1,4 +1,4 @@
-///! System and helpers for the update of portal cameras
+//! System and helpers for the update of portal cameras
 
 use bevy_app::prelude::*;
 use bevy_ecs::{

--- a/src/portals/material.rs
+++ b/src/portals/material.rs
@@ -14,7 +14,7 @@ use bevy_render::{
         SpecializedMeshPipelineError,
     },
 };
-use bevy_reflect::{TypeUuid, TypePath};
+use bevy_reflect::TypePath;
 use bevy_pbr::{MaterialPipelineKey, MaterialPipeline};
 
 /// Add the material logic to [PortalsPlugin](super::PortalsPlugin)
@@ -30,9 +30,8 @@ pub(super) fn build_material(app: &mut App) {
 }
 
 /// Material with the portal shader (renders the image without deformation using the mesh as a mask).
-#[derive(Asset, AsBindGroup, Clone, TypeUuid, TypePath)]
+#[derive(Asset, AsBindGroup, Clone, TypePath)]
 #[bind_group_data(PortalMaterialKey)]
-#[uuid = "436e9734-867f-4faf-9b5f-81703017a018"]
 pub struct PortalMaterial {
     #[texture(0)]
     #[sampler(1)]

--- a/src/portals/material.rs
+++ b/src/portals/material.rs
@@ -1,4 +1,4 @@
-///! Material for portal rendering
+//! Material for portal rendering
 
 use bevy_app::App;
 use bevy_asset::prelude::*;

--- a/src/portals/projection.rs
+++ b/src/portals/projection.rs
@@ -1,6 +1,6 @@
-///! Projection logic for portals.
-/// 
-/// This is currently unused because it makes Bevy crash in some situations: https://github.com/bevyengine/bevy/issues/9077
+//! Projection logic for portals.
+//!
+//! This is currently unused because it makes Bevy crash in some situations: https://github.com/bevyengine/bevy/issues/9077
 
 use bevy_app::App;
 use bevy_ecs::prelude::*;

--- a/src/portals/update.rs
+++ b/src/portals/update.rs
@@ -172,7 +172,7 @@ fn get_frustum(
         PortalMode::MaskedImageHalfSpaceFrustum(Some(half_space)) => {
             let rot = Quat::from_rotation_arc(
                 Vec3::NEG_Z,
-                destination_transform.forward(),
+                destination_transform.forward().normalize_or_zero(),
             );
             let near_half_space_normal = rot.mul_vec3(half_space.normal().into());
 
@@ -183,7 +183,7 @@ fn get_frustum(
         }
         PortalMode::MaskedImageHalfSpaceFrustum(None) => {
             let near_half_space_normal = destination_transform.forward();
-            let near_half_space_distance = - destination_transform.translation.dot(near_half_space_normal);
+            let near_half_space_distance = - destination_transform.translation.dot(near_half_space_normal.normalize_or_zero());
             frustum.half_spaces[4] = HalfSpace::new(near_half_space_normal.extend(near_half_space_distance))
         }
         _ => ()

--- a/src/portals/update.rs
+++ b/src/portals/update.rs
@@ -1,4 +1,4 @@
-///! System and helpers for the update of portal cameras
+//! System and helpers for the update of portal cameras
 
 use bevy_app::prelude::*;
 use bevy_asset::{Assets, Handle};
@@ -33,7 +33,7 @@ pub(super) fn build_update(app: &mut App) {
 }
 
 /// Moves the [PortalCamera] to follow the main camera relative to the portal and the destination.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn update_portal_cameras(
     mut commands: Commands,
     strategy: Res<PortalPartsDespawnStrategy>,


### PR DESCRIPTION
First, I want to say how happy I am that this project exists, and I love how well it works. However, the game I'm working on uses bevy 0.13, so I decided to take a crack at upgrading it myself.

The main issues I had were the need to add default `RenderLayers`, `Exposure`, and `CameraMainTextureUsages` components to the `portal_camera_entity` in the `portals::create::create_portal` function, and the need to change the binding group in the shader from 1 to 2.

All the examples seem to work now with bevy 0.13, although the light intensity may still need some tweaking given the exposure changes between bevy 0.12 and 0.13.

I also went through and replaced the deprecated shape types with the new primitive types.