### PR TITLE
Fix exposure at portal camera creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ if you want a bidirectional portal you can crate two portals manually
 - this crate doesn't handle moving stuff through the portal, it is only visual, more like a crystal ball
 - this crate doesn't handle raycasting through the portal, it has to be done manually
 - this crate doesn't handle changing the portal's or the destination's scale
+- this crate doesn't handle changing camera settings after creation
 
 ## Bevy versions
 | Bevy version | Bevy Basic Portals recommended version |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! - this crate doesn't handle raycasting through the portal, it has to be done manually
 //! - this crate doesn't handle resizing window/viewport of the main camera
 //! - this crate doesn't handle changing the portal's or the destination's scale
+//! - this crate doesn't handle changing camera settings after creation
 
 pub mod portals;
 pub use portals::*;

--- a/src/portals/create.rs
+++ b/src/portals/create.rs
@@ -16,7 +16,7 @@ use bevy_math::prelude::*;
 use bevy_pbr::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
-    camera::RenderTarget,
+    camera::{Exposure, RenderTarget},
     prelude::*,
     render_resource::{
         Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
@@ -182,6 +182,7 @@ fn create_portal(
         main_camera_tonemapping,
         main_camera_deband_dither,
         main_camera_color_grading,
+        main_camera_exposure,
     ) = if let Some(camera_entity) = create_portal.main_camera {
         main_camera_query.get(camera_entity).unwrap()
     } else {
@@ -288,7 +289,8 @@ fn create_portal(
                 ..SpatialBundle::default()
             },
             create_portal.render_layer.clone(),
-            camera_bundle.exposure,
+            *main_camera_exposure
+                .unwrap_or(&camera_bundle.exposure),
             camera_bundle.main_texture_usages,
         ))
         .id();
@@ -428,6 +430,7 @@ pub struct CreatePortalParams<'w, 's> {
             Option<&'static Tonemapping>,
             Option<&'static DebandDither>,
             Option<&'static ColorGrading>,
+            Option<&'static Exposure>,
         ),
     >,
     size_params: PortalImageSizeParams<'w, 's>,


### PR DESCRIPTION
Fixes https://github.com/Selene-Amanita/bevy_basic_portals/issues/6

Exposure was not replicated on the portal camera at portal camera creation. (oversight when migrating to Bevy 0.13)

Note that later change of exposure, or other camera settings, would not be synced after the portal creation. That is probably something that I should change someday.

Thank you @Pyroglyph for the issue, sorry I took a bit of time to react to it, and don't hesitate to tell me if you need me to publish a 0.6.1 version, I'm a bit lazy to do it if it's not really needed.