### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_basic_portals"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 categories = ["game-engines", "graphics", "rendering"]
 keywords = ["bevy", "portal", "mirror", "gamedev"]
@@ -11,30 +11,33 @@ repository = "https://github.com/Selene-Amanita/bevy_basic_portals"
 authors = ["Selene Amanita"]
 
 [dependencies]
-bevy_app = "0.16"
-bevy_asset = "0.16"
-bevy_color = "0.16"
-bevy_core_pipeline = "0.16"
-bevy_ecs = "0.16"
-bevy_image = "0.16"
-bevy_math = "0.16"
-bevy_pbr = "0.16"
-bevy_picking = { version = "0.16", optional = true }
-bevy_reflect = "0.16" # Could potentially be under a feature?
-bevy_render = "0.16"
-bevy_transform = "0.16"
-bevy_window = "0.16"
+bevy_app = "0.17"
+bevy_asset = "0.17"
+bevy_camera = "0.17"
+bevy_color = "0.17"
+bevy_core_pipeline = "0.17"
+bevy_ecs = "0.17"
+bevy_image = { version = "0.17", features = ["zstd_rust"] }
+bevy_math = "0.17"
+bevy_mesh = "0.17"
+bevy_pbr = "0.17"
+bevy_picking = { version = "0.17", optional = true }
+bevy_reflect = "0.17" # Could potentially be under a feature?
+bevy_render = "0.17"
+bevy_shader = "0.17"
+bevy_transform = "0.17"
+bevy_window = "0.17"
 tracing = { version = "0.1", default-features = false, features = ["std"] } # From bevy_utils
 uuid = { version = "1.11.0", features = ["v4"], optional = true }
 # All of the above can be replaced by:
-# bevy = { version = "0.16", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", ] }
+# bevy = { version = "0.17", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", ] }
 
 [features]
 default = ["picking_backend"]
 picking_backend = ["dep:bevy_picking", "dep:uuid"]
 
 [dev-dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_pbr",
@@ -45,8 +48,7 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_winit",
     "x11",
     "tonemapping_luts",
-    "ktx2",
-    "zstd",
+    "ktx2"
 ] }
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ if you want a bidirectional portal you can crate two portals manually
 ## Bevy versions
 | Bevy version | Bevy Basic Portals recommended version |
 |--------------|----------------------------------------|
+| 0.17.*       | 0.9.0                                  |
 | 0.16.*       | 0.8.0                                  |
 | 0.15.*       | 0.7.1                                  |
 | 0.14.*       | 0.6.0                                  |

--- a/assets/portal.wgsl
+++ b/assets/portal.wgsl
@@ -2,13 +2,13 @@
 #import bevy_pbr::mesh_bindings
 #import bevy_pbr::forward_io::VertexOutput
 
-@group(2) @binding(0)
+@group(#{MATERIAL_BIND_GROUP}) @binding(0)
 var texture: texture_2d<f32>;
-@group(2) @binding(1)
+@group(#{MATERIAL_BIND_GROUP}) @binding(1)
 var texture_sampler: sampler;
-@group(2) @binding(2)
+@group(#{MATERIAL_BIND_GROUP}) @binding(2)
 var<uniform> mirror_u: u32;
-@group(2) @binding(3)
+@group(#{MATERIAL_BIND_GROUP}) @binding(3)
 var<uniform> mirror_v: u32;
 
 @fragment

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -5,7 +5,8 @@
 use bevy::{
     color::palettes::basic::*,
     prelude::*,
-    render::{render_resource::Face, view::RenderLayers},
+    render::{render_resource::Face},
+    camera::visibility::RenderLayers,
 };
 
 use bevy_basic_portals::*;

--- a/examples/cube/scenes.rs
+++ b/examples/cube/scenes.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, render::view::RenderLayers};
+use bevy::{prelude::*, camera::visibility::RenderLayers};
 use bevy_basic_portals::*;
 use std::f32::consts::PI;
 

--- a/examples/picking/main.rs
+++ b/examples/picking/main.rs
@@ -55,11 +55,11 @@ fn setup(
 }
 
 fn on_event_change_color<E: std::fmt::Debug + Clone + Reflect, const MAKE_GREEN: bool>(
-    event: Trigger<Pointer<E>>,
+    trigger: On<Pointer<E>>,
     material_query: Query<&MeshMaterial3d<StandardMaterial>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let material_handle = material_query.get(event.entity()).unwrap();
+    let material_handle = material_query.get(trigger.event().entity).unwrap();
     let material = materials.get_mut(material_handle).unwrap();
     material.base_color = Color::Srgba(if MAKE_GREEN { GREEN } else { RED });
 }

--- a/helpers/pivot_cameras.rs
+++ b/helpers/pivot_cameras.rs
@@ -116,8 +116,8 @@ fn update_pivot_cameras(
     time: Res<Time>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mouse_input: Res<ButtonInput<MouseButton>>,
-    mut motion_evr: EventReader<MouseMotion>,
-    mut scroll_evr: EventReader<MouseWheel>,
+    mut motion_evr: MessageReader<MouseMotion>,
+    mut scroll_evr: MessageReader<MouseWheel>,
     mut pivot_camera_query: Query<(&mut Transform, &PivotCamera)>,
 ) {
     let still = Move::default();

--- a/helpers/textures.rs
+++ b/helpers/textures.rs
@@ -2,9 +2,9 @@
 use bevy::{
     prelude::*,
     render::{
-        render_asset::RenderAssetUsages,
         render_resource::{Extent3d, Face, TextureDimension, TextureFormat},
     },
+    asset::RenderAssetUsages,
 };
 
 /// Creates a colorful test pattern (copied from bevy's 3d_shape example)

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -3,14 +3,12 @@
 
 use crate::*;
 use bevy_app::prelude::*;
+use bevy_camera::NormalizedRenderTarget;
 use bevy_ecs::prelude::*;
 use bevy_math::Vec2;
 use bevy_picking::{
-    backend::prelude::*,
-    hover::HoverMap,
-    pointer::{Location, PointerAction, PointerInput},
+    backend::prelude::*, hover::HoverMap, pointer::{Location, PointerInput}
 };
-use bevy_render::camera::NormalizedRenderTarget;
 use bevy_transform::prelude::*;
 use tracing::debug;
 use uuid::Uuid;
@@ -19,13 +17,13 @@ pub(crate) struct PortalPickingBackendPlugin;
 
 impl Plugin for PortalPickingBackendPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, pick_through_portals.in_set(PickSet::Backend));
+        app.add_systems(PreUpdate, pick_through_portals.in_set(PickingSystems::Backend));
         app.add_observer(add_pointer);
     }
 }
 
 fn add_pointer(
-    trigger: Trigger<OnAdd, PortalCamera>,
+    trigger: Trigger<Add, PortalCamera>,
     mut commands: Commands,
     portal_cameras: Query<&PortalCamera>,
 ) {

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -23,11 +23,11 @@ impl Plugin for PortalPickingBackendPlugin {
 }
 
 fn add_pointer(
-    trigger: Trigger<Add, PortalCamera>,
+    trigger: On<Add, PortalCamera>,
     mut commands: Commands,
     portal_cameras: Query<&PortalCamera>,
 ) {
-    let portal_camera_entity = trigger.target();
+    let portal_camera_entity = trigger.event().entity;
     let portal_camera = portal_cameras.get(portal_camera_entity).unwrap();
 
     commands.entity(portal_camera_entity).insert((
@@ -44,7 +44,7 @@ pub fn pick_through_portals(
     portals: Query<(&PortalPart, &GlobalTransform), With<Portal>>,
     portal_parts: Query<&PortalParts>,
     portal_cameras: Query<(&PointerId, &PointerLocation), With<PortalCamera>>,
-    pointer_events: EventWriter<PointerInput>,
+    pointer_events: MessageWriter<PointerInput>,
 ) {
     /*for (pointer_id, hits) in hovers.iter() {
         for (entity, hit_data) in hits {

--- a/src/portals/api.rs
+++ b/src/portals/api.rs
@@ -1,11 +1,13 @@
 //! Components and structs to create portals without caring about their implementation
 
 use bevy_app::prelude::*;
+use bevy_camera::{primitives::HalfSpace, visibility::RenderLayers};
+use bevy_mesh::Mesh3d;
 use bevy_color::{Color, palettes::basic::GRAY};
 use bevy_ecs::prelude::*;
 use bevy_math::prelude::*;
 use bevy_reflect::Reflect;
-use bevy_render::{prelude::*, primitives::HalfSpace, render_resource::Face, view::RenderLayers};
+use bevy_render::render_resource::Face;
 use bevy_transform::prelude::*;
 
 use super::*;

--- a/src/portals/create.rs
+++ b/src/portals/create.rs
@@ -134,11 +134,11 @@ impl EntityCommand for CreatePortalCommand {
 /// It will also create debug elements if needed.
 /// It will then remove the [CreatePortal] component.
 pub fn create_portal_on_add(
-    trigger: Trigger<Add, CreatePortal>,
+    trigger: On<Add, CreatePortal>,
     mut create_params: CreatePortalParams,
     portal_query: Query<(&CreatePortal, &Transform, &Mesh3d)>, //TODO revert !dbg()
 ) {
-    let portal_entity = trigger.target();
+    let portal_entity = trigger.event().entity;
     let Ok((portal_create, portal_transform, mesh)) = portal_query.get(portal_entity) else {
         error!("Entity with CreatePortal lacks the other required components");
         return;

--- a/src/portals/create.rs
+++ b/src/portals/create.rs
@@ -1,10 +1,11 @@
 //! Components, systems and command for the creation of portals
 
+use bevy_camera::{Camera, Camera3d, Exposure, Projection, RenderTarget, visibility::Visibility};
+use bevy_mesh::{Mesh, Mesh3d};
 use bevy_app::prelude::*;
 use bevy_asset::prelude::*;
 use bevy_color::Alpha;
 use bevy_core_pipeline::{
-    prelude::*,
     tonemapping::{DebandDither, Tonemapping},
 };
 use bevy_ecs::{
@@ -16,8 +17,6 @@ use bevy_math::prelude::*;
 use bevy_pbr::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
-    camera::{Exposure, RenderTarget},
-    prelude::*,
     render_resource::{
         Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
     },
@@ -135,7 +134,7 @@ impl EntityCommand for CreatePortalCommand {
 /// It will also create debug elements if needed.
 /// It will then remove the [CreatePortal] component.
 pub fn create_portal_on_add(
-    trigger: Trigger<OnAdd, CreatePortal>,
+    trigger: Trigger<Add, CreatePortal>,
     mut create_params: CreatePortalParams,
     portal_query: Query<(&CreatePortal, &Transform, &Mesh3d)>, //TODO revert !dbg()
 ) {
@@ -356,7 +355,7 @@ fn create_portal(
                         _ => "Portal camera debug",
                     })
                     .to_owned(),
-                    resolution: WindowResolution::new(size.width as f32, size.height as f32),
+                    resolution: WindowResolution::new(size.width, size.height),
                     ..Window::default()
                 })
                 .id();
@@ -383,7 +382,7 @@ fn create_portal(
                 .insert(Visibility::default())
                 .with_children(|parent| {
                     parent.spawn((
-                        Mesh3d(meshes.add(Sphere::new(0.1).mesh().ico(5).unwrap())),
+                        Mesh3d(meshes.add(Sphere::new(0.1))),
                         MeshMaterial3d(materials.add(debug_color)),
                         create_portal.render_layer.clone(),
                     ));
@@ -413,7 +412,7 @@ fn create_portal(
                 .entity(portal_camera_entity)
                 .with_children(|parent| {
                     parent.spawn((
-                        Mesh3d(meshes.add(Sphere::new(0.1).mesh().ico(5).unwrap())),
+                        Mesh3d(meshes.add(Sphere::new(0.1))),
                         MeshMaterial3d(materials.add(debug_color)),
                         Visibility::Visible,
                         create_portal.render_layer.clone(),

--- a/src/portals/material.rs
+++ b/src/portals/material.rs
@@ -1,16 +1,17 @@
 //! Material for portal rendering
 
+use bevy_mesh::MeshVertexBufferLayoutRef;
+use bevy_shader::ShaderRef;
+use bevy_shader::Shader;
 use bevy_app::App;
-use bevy_asset::{prelude::*, weak_handle};
+use bevy_asset::{prelude::*, uuid_handle};
 use bevy_image::Image;
 use bevy_pbr::prelude::*;
 use bevy_pbr::{MaterialPipeline, MaterialPipelineKey};
 use bevy_reflect::TypePath;
 use bevy_render::{
-    mesh::MeshVertexBufferLayoutRef,
-    prelude::*,
     render_resource::{
-        AsBindGroup, Face, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+        AsBindGroup, Face, RenderPipelineDescriptor, SpecializedMeshPipelineError,
     },
 };
 
@@ -40,7 +41,7 @@ pub struct PortalMaterial {
     pub cull_mode: Option<Face>,
 }
 
-pub const PORTAL_SHADER_HANDLE: Handle<Shader> = weak_handle!("1EA3049777A909BDFFEB794905C6D106");
+pub const PORTAL_SHADER_HANDLE: Handle<Shader> = uuid_handle!("1EA3049777A909BDFFEB794905C6D106");
 
 impl Material for PortalMaterial {
     fn fragment_shader() -> ShaderRef {
@@ -48,7 +49,7 @@ impl Material for PortalMaterial {
     }
 
     fn specialize(
-        _: &MaterialPipeline<Self>,
+        _: &MaterialPipeline,
         descriptor: &mut RenderPipelineDescriptor,
         _: &MeshVertexBufferLayoutRef,
         key: MaterialPipelineKey<Self>,

--- a/src/portals/update.rs
+++ b/src/portals/update.rs
@@ -2,16 +2,14 @@
 
 use bevy_app::prelude::*;
 use bevy_asset::{Assets, Handle};
+use bevy_camera::{RenderTarget, prelude::*, primitives::{Frustum, HalfSpace}, visibility::VisibilitySystems};
 use bevy_ecs::{prelude::*, system::SystemParam};
 use bevy_image::Image;
 use bevy_math::{Dir3, UVec2, Vec3};
 use bevy_pbr::MeshMaterial3d;
 use bevy_render::{
-    camera::{CameraProjection, ManualTextureViews, RenderTarget},
     prelude::*,
-    primitives::{Frustum, HalfSpace},
     render_resource::Extent3d,
-    view::VisibilitySystems,
 };
 use bevy_transform::prelude::*;
 use bevy_window::{PrimaryWindow, Window, WindowRef};
@@ -25,7 +23,7 @@ pub(super) fn build_update(app: &mut App) {
         PostUpdate,
         (
             update_portal_cameras
-                .after(bevy_transform::TransformSystem::TransformPropagate)
+                .after(TransformSystems::Propagate)
                 .before(VisibilitySystems::UpdateFrusta),
             update_portal_camera_frusta.after(VisibilitySystems::UpdateFrusta),
         ),
@@ -270,7 +268,7 @@ fn get_frustum(
     projection: &Projection,
 ) -> Frustum {
     let view_projection =
-        projection.get_clip_from_view() * portal_camera_transform.compute_matrix().inverse();
+        projection.get_clip_from_view() * portal_camera_transform.to_matrix().inverse();
 
     let mut frustum = Frustum::from_clip_from_world_custom_far(
         &view_projection,
@@ -348,6 +346,7 @@ pub(super) fn get_viewport_size(
             RenderTarget::TextureView(handle) => texture_views
                 .get(handle)
                 .map(|texture_view| texture_view.size),
+            RenderTarget::None { size } => Some(*size),
         },
     }
 }


### PR DESCRIPTION
Just a straightforward migration from Bevy 0.16 to Bevy 0.17. No functional changes, just updates for Bevy 0.17 compatibility.

Of note:
- Many imports follow different paths due to Bevy refactoring where some things live in Bevy 0.17.
- Events now use new event syntax.
- The newly available `#{MATERIAL_BIND_GROUP}` is used to automatically get the correct group number in the portal shader.
- `weak_handle` is now `uuid_handle`.
- `PickSet` is now `PickingSystems`.
- `TransformPropagate` is now `Propagate`.
- `.compute_matrix()` is now `.to_matrix()`.
- Material specialize function now takes `&MaterialPipeline` instead of `&MaterialPipeline<Self>`.

See migration guide for further details: https://bevy.org/learn/migration-guides/0-16-to-0-17/

All examples have been tested and should be working.

Hope this helps! :)